### PR TITLE
Add support for systemd + sysvinit

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ When set to true, the python-pip package is installed. If the parameter is false
 then the pip command should be provided by some other means or yas3fs will not
 be installed.
 
+#####`init_system`
+
+Defines the type of init script/configuration to install out of `upstart`,
+`systemd` or `sysvinit`. If the parameter is unset, autodiscovery takes place.
+
+
 #####`mounts`
 
 A hash of mounts can be passed (possibly from hiera) as part of the class

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ invalidating caches on other nodes using SQS and SNS.
 ###What yas3fs affects
 
 * fuse package and configuration
-* upstart jobs that are used to manage yas3fs mounts
+* init jobs (sysvinit, upstart or systemd) that are used to manage yas3fs mounts
 * python-pip package (optional)
 
 ###Beginning with yas3fs
@@ -66,6 +66,12 @@ When set to true, the python-pip package is installed. If the parameter is false
 then the pip command should be provided by some other means or yas3fs will not
 be installed.
 
+#####`init_system`
+
+Defines the type of init script/configuration to install out of `upstart`,
+`systemd` or `sysvinit`. If the parameter is unset, autodiscovery takes place.
+
+
 #####`mounts`
 
 A hash of mounts can be passed (possibly from hiera) as part of the class
@@ -84,7 +90,7 @@ class { 'yas3fs':
 
 ####Defined Type: `yas3fs::mount`
 
-Mounts a bucket/path using fuse by creating an upstart job.
+Mounts a bucket/path using fuse by creating an init job.
 
 ```puppet
 yas3fs::mount { 'example-mount':
@@ -105,7 +111,7 @@ yas3fs::mount { 'example-mount':
 Control what to do with this mount. Valid values are `mounted` (default), `unmounted`, `absent`,
 and `present`.
 
-WARNING: setting ensure to `absent` removes the upstart configuration, but cannot
+WARNING: setting ensure to `absent` removes the service configuration, but cannot
 verify that the service is stopped.
 
 #####`s3_url`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ invalidating caches on other nodes using SQS and SNS.
 ###What yas3fs affects
 
 * fuse package and configuration
-* upstart jobs that are used to manage yas3fs mounts
+* init jobs (sysvinit, upstart or systemd) that are used to manage yas3fs mounts
 * python-pip package (optional)
 
 ###Beginning with yas3fs
@@ -84,7 +84,7 @@ class { 'yas3fs':
 
 ####Defined Type: `yas3fs::mount`
 
-Mounts a bucket/path using fuse by creating an upstart job.
+Mounts a bucket/path using fuse by creating an init job.
 
 ```puppet
 yas3fs::mount { 'example-mount':
@@ -105,7 +105,7 @@ yas3fs::mount { 'example-mount':
 Control what to do with this mount. Valid values are `mounted` (default), `unmounted`, `absent`,
 and `present`.
 
-WARNING: setting ensure to `absent` removes the upstart configuration, but cannot
+WARNING: setting ensure to `absent` removes the service configuration, but cannot
 verify that the service is stopped.
 
 #####`s3_url`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # A module to manage S3 mounts using yas3fs
 class yas3fs (
   $install_pip_package = $yas3fs::params::install_pip_package,
-  $install_init        = $yas3fs::params::install_init,
+  $init_system         = $yas3fs::params::init_system,
   $mounts              = {},
 ) inherits yas3fs::params {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 # A module to manage S3 mounts using yas3fs
 class yas3fs (
   $install_pip_package = $yas3fs::params::install_pip_package,
+  $install_init        = $yas3fs::params::install_init,
   $mounts              = {},
 ) inherits yas3fs::params {
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -40,7 +40,7 @@ define yas3fs::mount (
     }
   }
 
-  case $yas3fs::install_init {
+  case $yas3fs::init_system {
     'systemd': {
       exec { 'yas3fs_reload_systemd':
         # SystemD needs a reload after any unit file change
@@ -83,7 +83,7 @@ define yas3fs::mount (
       }
     }
     default : {
-      fail("Unknown init system ${yas3fs::install_init}, unable to install startup script for Yas3fs")
+      fail("Unknown init system ${yas3fs::init_system}, unable to install startup script for Yas3fs")
     }
   }
 

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -18,35 +18,73 @@ define yas3fs::mount (
 
   case $ensure {
     'mounted': {
-      $upstart_file_ensure = 'present'
+      $init_file_ensure = 'present'
       $service_ensure = 'running'
       $service_enable = true
     }
     'unmounted': {
-      $upstart_file_ensure = 'present'
+      $init_file_ensure = 'present'
       $service_ensure = 'stopped'
       $service_enable = false
     }
     'present': {
-      $upstart_file_ensure = 'present'
+      $init_file_ensure = 'present'
       $service_ensure = 'running'
       $service_enable = true
     }
     'absent': {
-      $upstart_file_ensure = 'absent'
+      $init_file_ensure = 'absent'
     }
     default: {
       fail('Only mounted, unmounted, and present are valid ensure values for yas3fs::mount')
     }
   }
 
-  file { "yas3fs-${name}.conf":
-    ensure  => $upstart_file_ensure,
-    path    => "/etc/init/s3fs-${name}.conf",
-    content => template('yas3fs/upstart.erb'),
-    owner   => 'root',
-    group   => 'root',
-    notify  => Service["s3fs-${name}"],
+  case $yas3fs::install_init {
+    'systemd': {
+      exec { 'yas3fs_reload_systemd':
+        # SystemD needs a reload after any unit file change
+        command     => 'systemctl daemon-reload',
+        path        => ["/bin", "/sbin", "/usr/bin", "/usr/sbin"],
+        refreshonly => true,
+        subscribe   => File["yas3fs-${name}"],
+        before      => Service['"s3fs-${name}"'],
+      }
+      file { "yas3fs-${name}":
+        ensure  => $init_file_ensure,
+        path    => "/etc/systemd/system/s3fs-${name}.service",
+        content => template('yas3fs/systemd.erb'),
+        owner   => 'root',
+        group   => 'root',
+	mode    => '0600',
+        notify  => Service["s3fs-${name}"],
+      }
+    }
+    'upstart': {
+      file { "yas3fs-${name}":
+        ensure  => $init_file_ensure,
+        path    => "/etc/init/s3fs-${name}.conf",
+        content => template('yas3fs/upstart.erb'),
+        owner   => 'root',
+        group   => 'root',
+	mode    => '0600',
+        notify  => Service["s3fs-${name}"],
+      }
+    }
+    'sysvinit': {
+      file { "yas3fs-${name}":
+        ensure  => $init_file_ensure,
+        path    => "/etc/init.d/s3fs-${name}",
+        content => template('yas3fs/sysvinit.erb'),
+        owner   => 'root',
+        group   => 'root',
+	mode    => '0700',
+        notify  => Service["s3fs-${name}"],
+      }
+    }
+    default : {
+      fail("Unknown init system ${yas3fs::install_init}, unable to install startup script for Yas3fs")
+    }
   }
 
   if $ensure == 'present' or $ensure == 'mounted' or $ensure == 'unmounted' {
@@ -54,7 +92,7 @@ define yas3fs::mount (
       ensure  => $service_ensure,
       enable  => $service_enable,
       require => [
-        File["yas3fs-${name}.conf"],
+        File["yas3fs-${name}"],
         Class['yas3fs'],
       ]
     }

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -48,7 +48,7 @@ define yas3fs::mount (
         path        => ["/bin", "/sbin", "/usr/bin", "/usr/sbin"],
         refreshonly => true,
         subscribe   => File["yas3fs-${name}"],
-        before      => Service['"s3fs-${name}"'],
+        before      => Service["s3fs-${name}"],
       }
       file { "yas3fs-${name}":
         ensure  => $init_file_ensure,

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -45,7 +45,7 @@ define yas3fs::mount (
       exec { 'yas3fs_reload_systemd':
         # SystemD needs a reload after any unit file change
         command     => 'systemctl daemon-reload',
-        path        => ["/bin", "/sbin", "/usr/bin", "/usr/sbin"],
+        path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'],
         refreshonly => true,
         subscribe   => File["yas3fs-${name}"],
         before      => Service["s3fs-${name}"],
@@ -56,7 +56,7 @@ define yas3fs::mount (
         content => template('yas3fs/systemd.erb'),
         owner   => 'root',
         group   => 'root',
-	mode    => '0600',
+        mode    => '0600',
         notify  => Service["s3fs-${name}"],
       }
     }
@@ -67,7 +67,7 @@ define yas3fs::mount (
         content => template('yas3fs/upstart.erb'),
         owner   => 'root',
         group   => 'root',
-	mode    => '0600',
+        mode    => '0600',
         notify  => Service["s3fs-${name}"],
       }
     }
@@ -78,7 +78,7 @@ define yas3fs::mount (
         content => template('yas3fs/sysvinit.erb'),
         owner   => 'root',
         group   => 'root',
-	mode    => '0700',
+        mode    => '0700',
         notify  => Service["s3fs-${name}"],
       }
     }

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -40,15 +40,15 @@ define yas3fs::mount (
     }
   }
 
-  case $yas3fs::install_init {
+  case $yas3fs::init_system {
     'systemd': {
       exec { 'yas3fs_reload_systemd':
         # SystemD needs a reload after any unit file change
         command     => 'systemctl daemon-reload',
-        path        => ["/bin", "/sbin", "/usr/bin", "/usr/sbin"],
+        path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'],
         refreshonly => true,
         subscribe   => File["yas3fs-${name}"],
-        before      => Service['"s3fs-${name}"'],
+        before      => Service["s3fs-${name}"],
       }
       file { "yas3fs-${name}":
         ensure  => $init_file_ensure,
@@ -56,7 +56,7 @@ define yas3fs::mount (
         content => template('yas3fs/systemd.erb'),
         owner   => 'root',
         group   => 'root',
-	mode    => '0600',
+        mode    => '0600',
         notify  => Service["s3fs-${name}"],
       }
     }
@@ -67,7 +67,7 @@ define yas3fs::mount (
         content => template('yas3fs/upstart.erb'),
         owner   => 'root',
         group   => 'root',
-	mode    => '0600',
+        mode    => '0600',
         notify  => Service["s3fs-${name}"],
       }
     }
@@ -78,12 +78,12 @@ define yas3fs::mount (
         content => template('yas3fs/sysvinit.erb'),
         owner   => 'root',
         group   => 'root',
-	mode    => '0700',
+        mode    => '0700',
         notify  => Service["s3fs-${name}"],
       }
     }
     default : {
-      fail("Unknown init system ${yas3fs::install_init}, unable to install startup script for Yas3fs")
+      fail("Unknown init system ${yas3fs::init_system}, unable to install startup script for Yas3fs")
     }
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -4,17 +4,27 @@ class yas3fs::package {
 
   if $::yas3fs::install_pip_package {
     package { 'python-pip':
-      ensure => present,
+      ensure        => present,
+      allow_virtual => true
     }
   }
 
   package { 'fuse':
-    ensure => present,
+    ensure        => present,
+    allow_virtual => true
+  }
+
+  if ($::osfamily == 'RedHat') {
+    package { 'fuse-libs':
+      ensure        => present,
+      allow_virtual => true
+    }
   }
 
   package { 'yas3fs':
-    ensure   => present,
-    provider => 'pip',
+    ensure        => present,
+    provider      => 'pip',
+    allow_virtual => true
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,5 @@
 # yas3fs defaults
 class yas3fs::params {
   $install_pip_package = true
+  $install_init        = $::initsystem
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,16 @@
 # yas3fs defaults
 class yas3fs::params {
   $install_pip_package = true
-  $install_init        = $::initsystem
+
+
+  # Use the jethrocarr-initfact module to determine which init system is in
+  # use, fall back to using upstart if missing to ensure compatibility with
+  # exiting puppet-yas3fs users.
+
+  if ($::initsystem) {
+    $init_system = $::initsystem
+  } else {
+    $init_system = 'upstart'
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,4 +2,10 @@
 class yas3fs::params {
   $install_pip_package = true
   $install_init        = $::initsystem
+
+  # Compatibility mode for existing users, if missing the jethrocarr-initfact
+  # module, we fall back to using the upstart init script/configuration.
+  if (!$install_init) {
+    $install_init = 'upstart'
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,9 +8,9 @@ class yas3fs::params {
   # exiting puppet-yas3fs users.
 
   if ($::initsystem) {
-    $install_init = $::initsystem
+    $init_system = $::initsystem
   } else {
-    $install_init = 'upstart'
+    $init_system = 'upstart'
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,16 @@
 # yas3fs defaults
 class yas3fs::params {
   $install_pip_package = true
-  $install_init        = $::initsystem
 
-  # Compatibility mode for existing users, if missing the jethrocarr-initfact
-  # module, we fall back to using the upstart init script/configuration.
-  if (!$install_init) {
+
+  # Use the jethrocarr-initfact module to determine which init system is in
+  # use, fall back to using upstart if missing to ensure compatibility with
+  # exiting puppet-yas3fs users.
+
+  if ($::initsystem) {
+    $install_init = $::initsystem
+  } else {
     $install_init = 'upstart'
   }
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "jethrocarr/initfact",
-      "version_requirement": ">=0.0.1"
+      "version_requirement": ">=1.0.0 <2.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -29,6 +29,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=4.4.0 <5.0.0"
+    },
+    {
+      "name": "jethrocarr/initfact",
+      "version_requirement": ">=0.0.1"
     }
   ]
 }

--- a/spec/classes/yas3fs_spec.rb
+++ b/spec/classes/yas3fs_spec.rb
@@ -36,7 +36,7 @@ describe 'yas3fs', :type => :class do
         }
       end
 
-      it { is_expected.to contain_file('yas3fs-test-mount.conf').with(
+      it { is_expected.to contain_file('yas3fs-test-mount').with(
         'ensure' => 'present',
         'path'   => '/etc/init/s3fs-test-mount.conf',
       ) }

--- a/spec/defines/mount_spec.rb
+++ b/spec/defines/mount_spec.rb
@@ -16,7 +16,7 @@ describe 'yas3fs::mount', :type => :define do
       :local_path => '/media/test-mount',
     } end
 
-    it { is_expected.to contain_file('yas3fs-test-mount.conf').with(
+    it { is_expected.to contain_file('yas3fs-test-mount').with(
       'ensure' => 'present',
       'path'   => '/etc/init/s3fs-test-mount.conf',
       'notify' => 'Service[s3fs-test-mount]',
@@ -39,7 +39,7 @@ describe 'yas3fs::mount', :type => :define do
       ]
     } end
 
-    it { is_expected.to contain_file('yas3fs-test-mount.conf').with(
+    it { is_expected.to contain_file('yas3fs-test-mount').with(
       'ensure' => 'present',
       'path'   => '/etc/init/s3fs-test-mount.conf',
       'notify' => 'Service[s3fs-test-mount]',

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -7,14 +7,14 @@ Description=S3-backed FUSE filesystem
 [Service]
 Type=simple
 <% if @aws_access_key_id -%>
-Environment=AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %> AWS_SECRET_ACCESS_KEY="<%= @aws_secret_access_key %>
+Environment=AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %> AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
 <% end -%>
 <% cmd_args = '' -%>
 <% @options.each do |v| -%>
 <% cmd_args = "#{cmd_args} --#{v}" -%>
 <% end -%>
 ExecStart=/usr/bin/yas3fs -f <%= cmd_args %> <%= @s3_url %> <%= @local_path %>
-ExecStop=umount <%= @local_path %>
+ExecStop=/bin/umount <%= @local_path %>
 RestartSec=5
 Restart=on-failure
 OOMScoreAdjust=-1000

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -13,7 +13,7 @@ Environment=AWS_ACCESS_KEY_ID="<%= @aws_access_key_id %>" AWS_SECRET_ACCESS_KEY=
 <% @options.each do |v| -%>
 <% cmd_args = "#{cmd_args} --#{v}" -%>
 <% end -%>
-ExecStart=/usr/local/bin/yas3fs -f <%= cmd_args %> "<%= @s3_url %>" "<%= @local_path %>"
+ExecStart=yas3fs -f <%= cmd_args %> "<%= @s3_url %>" "<%= @local_path %>"
 ExecStop=umount <%= @local_path %>
 RestartSec=5
 Restart=on-failure

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -7,7 +7,7 @@ Description=S3-backed FUSE filesystem
 [Service]
 Type=simple
 <% if @aws_access_key_id -%>
-Environment=AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %> AWS_SECRET_ACCESS_KEY="%= @aws_secret_access_key %>
+Environment=AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %> AWS_SECRET_ACCESS_KEY="<%= @aws_secret_access_key %>
 <% end -%>
 <% cmd_args = '' -%>
 <% @options.each do |v| -%>

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -1,0 +1,23 @@
+# Managed by puppet/yas3fs
+#
+
+[Unit]
+Description=S3-backed FUSE filesystem
+
+[Service]
+Type=simple
+<% if @aws_access_key_id -%>
+Environment=AWS_ACCESS_KEY_ID="<%= @aws_access_key_id %>" AWS_SECRET_ACCESS_KEY="<%= @aws_secret_access_key %>"
+<% end -%>
+<% cmd_args = '' -%>
+<% @options.each do |v| -%>
+<% cmd_args = "#{cmd_args} --#{v}" -%>
+<% end -%>
+ExecStart=/usr/local/bin/yas3fs -f <%= cmd_args %> "<%= @s3_url %>" "<%= @local_path %>"
+ExecStop=umount <%= @local_path %>
+RestartSec=5
+Restart=on-failure
+OOMScoreAdjust=-1000
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -13,7 +13,7 @@ Environment=AWS_ACCESS_KEY_ID="<%= @aws_access_key_id %>" AWS_SECRET_ACCESS_KEY=
 <% @options.each do |v| -%>
 <% cmd_args = "#{cmd_args} --#{v}" -%>
 <% end -%>
-ExecStart=yas3fs -f <%= cmd_args %> "<%= @s3_url %>" "<%= @local_path %>"
+ExecStart=/usr/local/bin/yas3fs -f <%= cmd_args %> "<%= @s3_url %>" "<%= @local_path %>"
 ExecStop=umount <%= @local_path %>
 RestartSec=5
 Restart=on-failure

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -13,6 +13,9 @@ Environment=AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %> AWS_SECRET_ACCESS_KEY=<%
 <% @options.each do |v| -%>
 <% cmd_args = "#{cmd_args} --#{v}" -%>
 <% end -%>
+# TODO: systemd requires a fully qualified path... but Puppet doesn't give us a
+# good way to query what the path to a particular binary is :-/ This may need
+# some further work, PRs welcome
 ExecStart=/usr/bin/yas3fs -f <%= cmd_args %> <%= @s3_url %> <%= @local_path %>
 ExecStop=/bin/umount <%= @local_path %>
 RestartSec=5

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -1,0 +1,26 @@
+# Managed by puppet/yas3fs
+#
+
+[Unit]
+Description=S3-backed FUSE filesystem
+
+[Service]
+Type=simple
+<% if @aws_access_key_id -%>
+Environment=AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %> AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
+<% end -%>
+<% cmd_args = '' -%>
+<% @options.each do |v| -%>
+<% cmd_args = "#{cmd_args} --#{v}" -%>
+<% end -%>
+# TODO: systemd requires a fully qualified path... but Puppet doesn't give us a
+# good way to query what the path to a particular binary is :-/ This may need
+# some further work, PRs welcome
+ExecStart=/usr/bin/yas3fs -f <%= cmd_args %> <%= @s3_url %> <%= @local_path %>
+ExecStop=/bin/umount <%= @local_path %>
+RestartSec=5
+Restart=on-failure
+OOMScoreAdjust=-1000
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -13,7 +13,7 @@ Environment=AWS_ACCESS_KEY_ID="<%= @aws_access_key_id %>" AWS_SECRET_ACCESS_KEY=
 <% @options.each do |v| -%>
 <% cmd_args = "#{cmd_args} --#{v}" -%>
 <% end -%>
-ExecStart=/usr/local/bin/yas3fs -f <%= cmd_args %> "<%= @s3_url %>" "<%= @local_path %>"
+ExecStart=/usr/bin/yas3fs -f <%= cmd_args %> "<%= @s3_url %>" "<%= @local_path %>"
 ExecStop=umount <%= @local_path %>
 RestartSec=5
 Restart=on-failure

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -7,7 +7,7 @@ Description=S3-backed FUSE filesystem
 [Service]
 Type=simple
 <% if @aws_access_key_id -%>
-Environment=AWS_ACCESS_KEY_ID="<%= @aws_access_key_id %>" AWS_SECRET_ACCESS_KEY="<%= @aws_secret_access_key %>"
+Environment=AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %> AWS_SECRET_ACCESS_KEY="%= @aws_secret_access_key %>
 <% end -%>
 <% cmd_args = '' -%>
 <% @options.each do |v| -%>

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -13,7 +13,7 @@ Environment=AWS_ACCESS_KEY_ID="<%= @aws_access_key_id %>" AWS_SECRET_ACCESS_KEY=
 <% @options.each do |v| -%>
 <% cmd_args = "#{cmd_args} --#{v}" -%>
 <% end -%>
-ExecStart=/usr/bin/yas3fs -f <%= cmd_args %> "<%= @s3_url %>" "<%= @local_path %>"
+ExecStart=/usr/bin/yas3fs -f <%= cmd_args %> <%= @s3_url %> <%= @local_path %>
 ExecStop=umount <%= @local_path %>
 RestartSec=5
 Restart=on-failure

--- a/templates/sysvinit.erb
+++ b/templates/sysvinit.erb
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Managed by the puppet-yas3fs module.
+
+
+### BEGIN INIT INFO
+# Provides:          s3fs-<%= @name %>
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# chkconfig:         - 98 02
+# Short-Description: Yas3fs Filesystem Mount
+# Description:       Sets up a FUSE mount for an S3-backed filesystem using Yas3fs
+### END INIT INFO
+
+PATH=$PATH:/usr/local/bin
+
+export S3_URL="<%= @s3_url %>"
+export LOCAL_PATH="<%= @local_path %>"
+
+<% if @aws_access_key_id -%>
+export AWS_ACCESS_KEY_ID="<%= @aws_access_key_id %>"
+export AWS_SECRET_ACCESS_KEY="<%= @aws_secret_access_key %>"
+<% end -%>
+
+<% cmd_args = '' -%>
+<% @options.each do |v| -%>
+<% cmd_args = "#{cmd_args} --#{v}" -%>
+<% end -%>
+
+name=`basename $0`
+pid_file="/var/run/$name.pid"
+
+get_pid() {
+    touch "$pid_file"
+    cat "$pid_file"
+}
+
+is_running() {
+    # Not much point checking the PID, the mount is what matters.
+    mount | grep " $LOCAL_PATH " 2>&1 > /dev/null
+}
+
+case "$1" in
+    start)
+    if is_running; then
+        echo "Already started"
+    else
+        echo "Starting $name"
+	<%= "( yas3fs -f #{cmd_args} \"$S3_URL\" \"$LOCAL_PATH\" & echo $! > \"$pid_file\" ) 2>&1 | logger -t yas3fs-#{@name} &" %>
+	sleep 1 # avoid trying to get the PID before it exists yet
+        echo "Running as PID `get_pid`"
+
+	sleep 5 # it can take a few seconds to mount the filesystem
+	if ! is_running; then
+            echo "Unable to start, see syslog for details"
+            exit 1
+        fi
+    fi
+    ;;
+    stop)
+    if is_running; then
+        echo -n "Stopping $name.."
+	umount "$LOCAL_PATH"
+
+        for i in {1..10}
+        do
+            if ! is_running; then
+                break
+            fi
+
+            echo -n "."
+            sleep 1
+        done
+        echo
+
+        if is_running; then
+            echo "Not stopped; filesystem may be in use which is preventing proper shutdown"
+            exit 1
+        else
+            echo "Stopped"
+            if [ -f "$pid_file" ]; then
+                rm "$pid_file"
+            fi
+        fi
+    else
+        echo "Not running"
+    fi
+    ;;
+    restart)
+    $0 stop
+    if is_running; then
+        echo "Unable to stop, will not attempt to start"
+        exit 1
+    fi
+    $0 start
+    ;;
+    status)
+    if is_running; then
+        echo "Running"
+    else
+        echo "Stopped"
+        exit 1
+    fi
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/templates/sysvinit.erb
+++ b/templates/sysvinit.erb
@@ -47,10 +47,11 @@ case "$1" in
         echo "Already started"
     else
         echo "Starting $name"
-	<%= "( /usr/local/bin/yas3fs -f #{cmd_args} \"$S3_URL\" \"$LOCAL_PATH\" & echo $! > \"$pid_file\" ) 2>&1 | logger -t yas3fs-#{@name} &" %>
+	<%= "( yas3fs -f #{cmd_args} \"$S3_URL\" \"$LOCAL_PATH\" & echo $! > \"$pid_file\" ) 2>&1 | logger -t yas3fs-#{@name} &" %>
 	sleep 1 # avoid trying to get the PID before it exists yet
         echo "Running as PID `get_pid`"
 
+	sleep 5 # it can take a few seconds to mount the filesystem
 	if ! is_running; then
             echo "Unable to start, see syslog for details"
             exit 1

--- a/templates/sysvinit.erb
+++ b/templates/sysvinit.erb
@@ -15,10 +15,6 @@
 
 PATH=$PATH:/usr/local/bin
 
-dir="/tmp"
-cmd_app="pupistry apply --daemon"
-cmd_log="logger -s -t pupistry"
-
 export S3_URL="<%= @s3_url %>"
 export LOCAL_PATH="<%= @local_path %>"
 
@@ -32,8 +28,6 @@ export AWS_SECRET_ACCESS_KEY="<%= @aws_secret_access_key %>"
 <% cmd_args = "#{cmd_args} --#{v}" -%>
 <% end -%>
 
-
-
 name=`basename $0`
 pid_file="/var/run/$name.pid"
 
@@ -43,8 +37,8 @@ get_pid() {
 }
 
 is_running() {
- # Not much point checking the PID, the mount is what matters.
- `mount|grep " $LOCAL_PATH "|wc -l`
+    # Not much point checking the PID, the mount is what matters.
+    mount | grep " $LOCAL_PATH " 2>&1 > /dev/null
 }
 
 case "$1" in
@@ -53,7 +47,7 @@ case "$1" in
         echo "Already started"
     else
         echo "Starting $name"
-	<%= "( /usr/local/bin/yas3fs -f #{cmd_args} \"$S3_URL\" \"$LOCAL_PATH\") & echo $! > \"$pid_file\" ) 2>&1 | logger -t yas3fs-#{@name} &" %>
+	<%= "( /usr/local/bin/yas3fs -f #{cmd_args} \"$S3_URL\" \"$LOCAL_PATH\" & echo $! > \"$pid_file\" ) 2>&1 | logger -t yas3fs-#{@name} &" %>
 	sleep 1 # avoid trying to get the PID before it exists yet
         echo "Running as PID `get_pid`"
 

--- a/templates/sysvinit.erb
+++ b/templates/sysvinit.erb
@@ -1,0 +1,117 @@
+#!/bin/sh
+# Managed by the puppet-yas3fs module.
+
+
+### BEGIN INIT INFO
+# Provides:          s3fs-<%= @name %>
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# chkconfig:         - 98 02
+# Short-Description: Yas3fs Filesystem Mount
+# Description:       Sets up a FUSE mount for an S3-backed filesystem using Yas3fs
+### END INIT INFO
+
+PATH=$PATH:/usr/local/bin
+
+dir="/tmp"
+cmd_app="pupistry apply --daemon"
+cmd_log="logger -s -t pupistry"
+
+export S3_URL="<%= @s3_url %>"
+export LOCAL_PATH="<%= @local_path %>"
+
+<% if @aws_access_key_id -%>
+export AWS_ACCESS_KEY_ID="<%= @aws_access_key_id %>"
+export AWS_SECRET_ACCESS_KEY="<%= @aws_secret_access_key %>"
+<% end -%>
+
+<% cmd_args = '' -%>
+<% @options.each do |v| -%>
+<% cmd_args = "#{cmd_args} --#{v}" -%>
+<% end -%>
+
+
+
+name=`basename $0`
+pid_file="/var/run/$name.pid"
+
+get_pid() {
+    touch "$pid_file"
+    cat "$pid_file"
+}
+
+is_running() {
+ # Not much point checking the PID, the mount is what matters.
+ `mount|grep " $LOCAL_PATH "|wc -l`
+}
+
+case "$1" in
+    start)
+    if is_running; then
+        echo "Already started"
+    else
+        echo "Starting $name"
+	<%= "( /usr/local/bin/yas3fs -f #{cmd_args} \"$S3_URL\" \"$LOCAL_PATH\") & echo $! > \"$pid_file\" ) 2>&1 | logger -t yas3fs-#{@name} &" %>
+	sleep 1 # avoid trying to get the PID before it exists yet
+        echo "Running as PID `get_pid`"
+
+	if ! is_running; then
+            echo "Unable to start, see syslog for details"
+            exit 1
+        fi
+    fi
+    ;;
+    stop)
+    if is_running; then
+        echo -n "Stopping $name.."
+	umount "$LOCAL_PATH"
+
+        for i in {1..10}
+        do
+            if ! is_running; then
+                break
+            fi
+
+            echo -n "."
+            sleep 1
+        done
+        echo
+
+        if is_running; then
+            echo "Not stopped; filesystem may be in use which is preventing proper shutdown"
+            exit 1
+        else
+            echo "Stopped"
+            if [ -f "$pid_file" ]; then
+                rm "$pid_file"
+            fi
+        fi
+    else
+        echo "Not running"
+    fi
+    ;;
+    restart)
+    $0 stop
+    if is_running; then
+        echo "Unable to stop, will not attempt to start"
+        exit 1
+    fi
+    $0 start
+    ;;
+    status)
+    if is_running; then
+        echo "Running"
+    else
+        echo "Stopped"
+        exit 1
+    fi
+    ;;
+    *)
+    echo "Usage: $0 {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
This PR adds support for systemd, sysvinit and of course, retains the existing upstart support. It makes this module much more useful for anyone using non-Ubuntu distributions.

It works uses my module (https://github.com/jethrocarr/puppet-initfact) for init system detection, but if it is not present, falls back to upstart so the new module will not break anything for existing users whom pull the latest version.

In future hopefully Puppet will expose a native fact for init detection, in which case it will be simple to drop the dependency on puppet-initfact and be able to just stick with the native.
