### PR TITLE
[WIP] Systemd Service Bin Paths

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,10 +5,10 @@ class yas3fs (
   $mounts              = {},
 ) inherits yas3fs::params {
 
-  anchor { 'yas3fs::begin': } ->
-  class { '::yas3fs::package': } ->
-  class { '::yas3fs::config': } ->
-  anchor { 'yas3fs::end':}
+  anchor { 'yas3fs::begin': }
+  -> class { '::yas3fs::package': }
+  -> class { '::yas3fs::config': }
+  -> anchor { 'yas3fs::end':}
 
   if !empty($mounts) {
     create_resources('yas3fs::mount', $mounts)

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -45,7 +45,7 @@ define yas3fs::mount (
       exec { "yas3fs_reload_systemd-${name}":
         # SystemD needs a reload after any unit file change
         command     => 'systemctl daemon-reload',
-        path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin'],
+        path        => ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin'],
         refreshonly => true,
         subscribe   => File["yas3fs-${name}"],
         before      => Service["s3fs-${name}"],

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -16,8 +16,8 @@ Environment=AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %> AWS_SECRET_ACCESS_KEY=<%
 # TODO: systemd requires a fully qualified path... but Puppet doesn't give us a
 # good way to query what the path to a particular binary is :-/ This may need
 # some further work, PRs welcome
-ExecStart=/usr/bin/yas3fs -f <%= cmd_args %> <%= @s3_url %> <%= @local_path %>
-ExecStop=/bin/umount <%= @local_path %>
+ExecStart=/usr/bin/env yas3fs -f <%= cmd_args %> <%= @s3_url %> <%= @local_path %>
+ExecStop=/usr/bin/env umount <%= @local_path %>
 RestartSec=5
 Restart=on-failure
 OOMScoreAdjust=-1000


### PR DESCRIPTION
This address the following issue on Ubuntu 16.04.2:

The path to `yas3fs` is `/usr/local/bin/yas3fs` on my system, which is not taken into account by the systemd template and config parameters.

```text
Jun 17 11:14:46 demo-openstack1 systemd[1]: s3fs-s3homes.service: Service hold-off time over, scheduling restart.
Jun 17 11:14:46 demo-openstack1 systemd[1]: Stopped S3-backed FUSE filesystem.
Jun 17 11:14:46 demo-openstack1 systemd[1]: Started S3-backed FUSE filesystem.
Jun 17 11:14:46 demo-openstack1 systemd[2120]: s3fs-s3homes.service: Failed at step EXEC spawning /usr/bin/yas3fs: No such file or directory
Jun 17 11:14:46 demo-openstack1 systemd[1]: s3fs-s3homes.service: Main process exited, code=exited, status=203/EXEC
Jun 17 11:14:46 demo-openstack1 umount[2122]: umount: /Users: not mounted
Jun 17 11:14:46 demo-openstack1 systemd[1]: s3fs-s3homes.service: Control process exited, code=exited status=32
Jun 17 11:14:46 demo-openstack1 systemd[1]: s3fs-s3homes.service: Unit entered failed state.
Jun 17 11:14:46 demo-openstack1 systemd[1]: s3fs-s3homes.service: Failed with result 'exit-code'.
```

This also converts the systemd configuration to use `/usr/bin/env` to discover bin files. This is more compatible then hard-coded paths.