### PR TITLE
Install yas3fs from github source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,17 @@
 # A module to manage S3 mounts using yas3fs
 class yas3fs (
-  $install_pip_package = $yas3fs::params::install_pip_package,
-  $init_system         = $yas3fs::params::init_system,
-  $mounts              = {},
+  $install_pip_package          = $yas3fs::params::install_pip_package,
+  $init_system                  = $yas3fs::params::init_system,
+  $mounts                       = {},
+  Enum['pip', 'vcs'] $provider  = $yas3fs::params::provider,
+  $vcs_remote                   = $yas3fs::params::vcs_remote,
+  $vcs_revision                 = $yas3fs::params::vcs_revision,
 ) inherits yas3fs::params {
 
-  anchor { 'yas3fs::begin': } ->
-  class { '::yas3fs::package': } ->
-  class { '::yas3fs::config': } ->
-  anchor { 'yas3fs::end':}
+  anchor { 'yas3fs::begin': }
+  -> class { '::yas3fs::package': }
+  -> class { '::yas3fs::config': }
+  -> anchor { 'yas3fs::end':}
 
   if !empty($mounts) {
     create_resources('yas3fs::mount', $mounts)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,11 @@
 # A module to manage S3 mounts using yas3fs
 class yas3fs (
-  $install_pip_package          = $yas3fs::params::install_pip_package,
-  $init_system                  = $yas3fs::params::init_system,
+  $install_pip_package          = $::yas3fs::params::install_pip_package,
+  $init_system                  = $::yas3fs::params::init_system,
   $mounts                       = {},
-  Enum['pip', 'vcs'] $provider  = $yas3fs::params::provider,
-  $vcs_remote                   = $yas3fs::params::vcs_remote,
-  $vcs_revision                 = $yas3fs::params::vcs_revision,
+  Enum['pip', 'vcs'] $provider  = $::yas3fs::params::provider,
+  $vcs_remote                   = $::yas3fs::params::vcs_remote,
+  $vcs_revision                 = $::yas3fs::params::vcs_revision,
 ) inherits yas3fs::params {
 
   anchor { 'yas3fs::begin': }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -34,6 +34,18 @@ class yas3fs::package (
       }
     }
     'vcs': {
+      # yas3fs setup.py barfs on setuptools and boto3 installs.
+      # I think it is RHEL's fault
+      package { 'setuptools':
+        ensure        => '2.2',
+        provider      => 'pip',
+        allow_virtual => true
+      }
+      package { 'boto3':
+        ensure        => 'present',
+        provider      => 'pip',
+        allow_virtual => true
+      }
       vcsrepo { '/var/tmp/yas3fs':
         # Just 'present' so we do not beatup our git repository
         # provider every 30mins
@@ -47,7 +59,7 @@ class yas3fs::package (
         command => 'python /var/tmp/yas3fs/setup.py install',
         creates => '/usr/bin/yas3fs',
         cwd     => '/var/tmp/yas3fs',
-        require => Vcsrepo['/var/tmp/yas3fs'],
+        require => [Package['setuptools', 'boto3'],Vcsrepo['/var/tmp/yas3fs']],
       }
     }
     default: {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -46,6 +46,7 @@ class yas3fs::package (
       exec { 'install yas3fs':
         command => 'python /var/tmp/yas3fs/setup.py install',
         creates => '/usr/bin/yas3fs',
+        cwd     => '/var/tmp/yas3fs',
         require => Vcsrepo['/var/tmp/yas3fs'],
       }
     }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -44,7 +44,7 @@ class yas3fs::package (
       }
 
       exec { 'install yas3fs':
-        command => 'python setup.py install',
+        command => 'python /var/tmp/yas3fs/setup.py install',
         creates => '/usr/bin/yas3fs',
         require => Vcsrepo['/var/tmp/yas3fs'],
       }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,5 +1,9 @@
 # yas3fs package install
-class yas3fs::package {
+class yas3fs::package (
+  $provider     = $yas3fs::provider,
+  $vcs_remote   = $yas3fs::vcs_remote,
+  $vcs_revision = $yas3fs::vcs_revision,
+){
   assert_private()
 
   if $::yas3fs::install_pip_package {
@@ -21,10 +25,36 @@ class yas3fs::package {
     }
   }
 
-  package { 'yas3fs':
-    ensure        => present,
-    provider      => 'pip',
-    allow_virtual => true
-  }
+  case $provider {
+    'pip': {
+      package { 'yas3fs':
+        ensure        => present,
+        provider      => 'pip',
+        allow_virtual => true
+      }
+    }
+    'vcs': {
+      vcsrepo { '/var/tmp/yas3fs':
+        # Just 'present' so we do not beatup our git repository
+        # provider every 30mins
+        ensure   => present,
+        provider => git,
+        source   => $vcs_remote,
+        revision => $vcs_revision,
+      }
 
+      exec { 'install yas3fs':
+        command => 'python setup.py install',
+        creates => '/usr/bin/yas3fs',
+        require => Vcsrepo['/var/tmp/yas3fs'],
+      }
+    }
+    default: {
+      package { 'yas3fs':
+        ensure        => present,
+        provider      => 'pip',
+        allow_virtual => true
+      }
+    }
+  }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,8 +1,8 @@
 # yas3fs package install
 class yas3fs::package (
-  $provider     = $yas3fs::provider,
-  $vcs_remote   = $yas3fs::vcs_remote,
-  $vcs_revision = $yas3fs::vcs_revision,
+  $provider     = $::yas3fs::provider,
+  $vcs_remote   = $::yas3fs::vcs_remote,
+  $vcs_revision = $::yas3fs::vcs_revision,
 ){
   assert_private()
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -34,6 +34,12 @@ class yas3fs::package (
       }
     }
     'vcs': {
+      #Remove pip installed package before installing from source.
+      package { 'yas3fs':
+        ensure        => absent,
+        provider      => 'pip',
+        allow_virtual => true
+      }
       # yas3fs setup.py barfs on setuptools and boto3 installs.
       # I think it is RHEL's fault
       package { 'setuptools':
@@ -59,7 +65,7 @@ class yas3fs::package (
         command => 'python /var/tmp/yas3fs/setup.py install',
         creates => '/usr/bin/yas3fs',
         cwd     => '/var/tmp/yas3fs',
-        require => [Package['setuptools', 'boto3'],Vcsrepo['/var/tmp/yas3fs']],
+        require => [Package['yas3fs', 'setuptools', 'boto3'],Vcsrepo['/var/tmp/yas3fs']],
       }
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,9 @@
 # yas3fs defaults
 class yas3fs::params {
   $install_pip_package = true
-
+  $provider = 'pip'
+  $vcs_remote = 'https://github.com/danilop/yas3fs.git'
+  $vcs_revision = 'master'
 
   # Use the jethrocarr-initfact module to determine which init system is in
   # use, fall back to using upstart if missing to ensure compatibility with


### PR DESCRIPTION
A sloppy attempt at getting latest 2.4.6 installed from github source.
It at least gets the job done on RHEL7.9 up to date.

I hope others can benefit as `pip install yas3fs` is failing for me now.

To install from github, set yas3fs::provider: 'vcs'

Related to https://github.com/danilop/yas3fs/issues/191 and https://github.com/danilop/yas3fs/issues/192